### PR TITLE
Rewrite with callbacks

### DIFF
--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -76,88 +76,89 @@ function! s:FsdnRequest(query)
     return { 'Query': a:query }
 endfunction
 
-function! s:call(method, params)
-    let result = []
-    call LanguageClient#Call(a:method, a:params, result)
-    while len(result) == 0
-        sleep 10m
-    endwhile
-    let res = result[0]
-    return res
+function! s:call(method, params, cont)
+    call LanguageClient#Call(a:method, a:params, a:cont)
 endfunction
 
-function! s:signature(filePath, line, character)
-    return s:call('fsharp/signature', s:TextDocumentPositionParams(a:filePath, a:line, a:character))
+function! s:signature(filePath, line, character, cont)
+    return s:call('fsharp/signature', s:TextDocumentPositionParams(a:filePath, a:line, a:character), a:cont)
 endfunction
-function! s:signatureData(filePath, line, character)
-    return s:call('fsharp/signatureData', s:TextDocumentPositionParams(a:filePath, a:line, a:character))
+function! s:signatureData(filePath, line, character, cont)
+    return s:call('fsharp/signatureData', s:TextDocumentPositionParams(a:filePath, a:line, a:character), a:cont)
 endfunction
-function! s:lineLens(projectPath)
-    return s:call('fsharp/lineLens', s:ProjectParms(a:projectPath))
+function! s:lineLens(projectPath, cont)
+    return s:call('fsharp/lineLens', s:ProjectParms(a:projectPath), a:cont)
 endfunction
-function! s:compilerLocation()
-    return s:call('fsharp/compilerLocation', {})
+function! s:compilerLocation(cont)
+    return s:call('fsharp/compilerLocation', {}, a:cont)
 endfunction
-function! s:compile(projectPath)
-    return s:call('fsharp/compile', s:ProjectParms(a:projectPath))
+function! s:compile(projectPath, cont)
+    return s:call('fsharp/compile', s:ProjectParms(a:projectPath), a:cont)
 endfunction
-function! s:workspacePeek(directory, depth, excludedDirs)
-    return s:call('fsharp/workspacePeek', s:WorkspacePeekRequest(a:directory, a:depth, a:excludedDirs))
+function! s:workspacePeek(directory, depth, excludedDirs, cont)
+    return s:call('fsharp/workspacePeek', s:WorkspacePeekRequest(a:directory, a:depth, a:excludedDirs), a:cont)
 endfunction
-function! s:workspaceLoad(files)
-    return s:call('fsharp/workspaceLoad', s:WorkspaceLoadParms(a:files))
+function! s:workspaceLoad(files, cont)
+    return s:call('fsharp/workspaceLoad', s:WorkspaceLoadParms(a:files), a:cont)
 endfunction
-function! s:project(projectPath)
-    return s:call('fsharp/project', s:ProjectParms(a:projectPath))
+function! s:project(projectPath, cont)
+    return s:call('fsharp/project', s:ProjectParms(a:projectPath), a:cont)
 endfunction
-function! s:fsdn(signature)
-    return s:call('fsharp/fsdn', s:FsdnRequest(a:signature))
+function! s:fsdn(signature, cont)
+    return s:call('fsharp/fsdn', s:FsdnRequest(a:signature), a:cont)
 endfunction
-function! s:f1Help(filePath, line, character)
-    return s:call('fsharp/f1Help', s:TextDocumentPositionParams(a:filePath, a:line, a:character))
+function! s:f1Help(filePath, line, character, cont)
+    return s:call('fsharp/f1Help', s:TextDocumentPositionParams(a:filePath, a:line, a:character), a:cont)
 endfunction
-function! fsharp#documentation(filePath, line, character)
-    return s:call('fsharp/documentation', s:TextDocumentPositionParams(a:filePath, a:line, a:character))
+function! fsharp#documentation(filePath, line, character, cont)
+    return s:call('fsharp/documentation', s:TextDocumentPositionParams(a:filePath, a:line, a:character), a:cont)
 endfunction
-function! s:documentationSymbol(xmlSig, assembly)
-    return s:call('fsharp/documentationSymbol', s:DocumentationForSymbolRequest(a:xmlSig, a:assembly))
+function! s:documentationSymbol(xmlSig, assembly, cont)
+    return s:call('fsharp/documentationSymbol', s:DocumentationForSymbolRequest(a:xmlSig, a:assembly), a:cont)
 endfunction
 
-function! s:findWorkspace(dir)
-    let result = s:workspacePeek(a:dir, g:fsharp#workspace_mode_peek_deep_level, [])
-    let content = json_decode(result.result.content)
-    if len(content.Data.Found) < 1
-        return []
-    endif
-    let workspace = { 'Type': 'none' }
-    for found in content.Data.Found
-        if workspace.Type == 'none'
-            let workspace = found
-        elseif found.Type == 'solution'
-            if workspace.Type == 'project' then
+function! s:findWorkspace(dir, cont)
+    let s:cont_findWorkspace = a:cont
+    function! s:callback_findWorkspace(result)
+        let result = a:result
+        let content = json_decode(result.result.content)
+        if len(content.Data.Found) < 1
+            return []
+        endif
+        let workspace = { 'Type': 'none' }
+        for found in content.Data.Found
+            if workspace.Type == 'none'
                 let workspace = found
-            else
-                let curLen = len(workspace.Data.Items)
-                let newLen = len(found.Data.Items)
-                if newLen > curLen then
+            elseif found.Type == 'solution'
+                if workspace.Type == 'project' then
                     let workspace = found
+                else
+                    let curLen = len(workspace.Data.Items)
+                    let newLen = len(found.Data.Items)
+                    if newLen > curLen then
+                        let workspace = found
+                    endif
                 endif
             endif
+        endfor
+        if workspace.Type == 'solution'
+            call s:cont_findWorkspace([workspace.Data.Path])
+        else
+            call s:cont_findWorkspace(workspace.Data.Fsprojs)
         endif
-    endfor
-    if workspace.Type == 'solution'
-        return [workspace.Data.Path]
-    else
-        return workspace.Data.Fsprojs
-    endif
+    endfunction
+    call s:workspacePeek(a:dir, g:fsharp#workspace_mode_peek_deep_level, [], function("s:callback_findWorkspace"))
 endfunction
 
 let s:workspace = []
 
 function! s:load(arg)
-    call s:workspaceLoad(a:arg)
-    echo "[FSAC] Workspace loaded: " . join(a:arg, ', ')
-    let s:workspace = s:workspace + a:arg
+    let s:loading_workspace = a:arg
+    function! s:callback_load(_)
+        echo "[FSAC] Workspace loaded: " . join(s:loading_workspace, ', ')
+        let s:workspace = s:workspace + s:loading_workspace
+    endfunction
+    call s:workspaceLoad(a:arg, function("s:callback_load"))
 endfunction
 
 function! fsharp#loadProject(...)
@@ -172,14 +173,16 @@ function! fsharp#loadWorkspaceAuto()
     if &ft == 'fsharp'
         echom "[FSAC] Loading workspace..."
         let bufferDirectory = fnamemodify(resolve(expand('%:p')), ':h')
-        call s:load(s:findWorkspace(bufferDirectory))
+        call s:findWorkspace(bufferDirectory, function("s:load"))
     endif
 endfunction
 
 function! fsharp#reloadProjects()
     if len(s:workspace) > 0
-        call s:workspaceLoad(s:workspace)
-        call s:prompt("[FSAC] Workspace reloaded.")
+        function! s:callback_reloadProjects(_)
+            call s:prompt("[FSAC] Workspace reloaded.")
+        endfunction
+        call s:workspaceLoad(s:workspace, function("s:callback_reloadProjects"))
     else
         echom "[FSAC] Workspace is empty"
     endif
@@ -192,13 +195,16 @@ function! fsharp#OnFSProjSave()
 endfunction
 
 function! fsharp#showSignature()
-    let result = s:signature(expand('%:p'), line('.') - 1, col('.') - 1)
-    if exists('result.result.content')
-        let content = json_decode(result.result.content)
-        if exists('content.Data')
-            echom substitute(content.Data, '\n\+$', ' ', 'g')
+    function! s:callback_showSignature(result)
+        let result = a:result
+        if exists('result.result.content')
+            let content = json_decode(result.result.content)
+            if exists('content.Data')
+                echom substitute(content.Data, '\n\+$', ' ', 'g')
+            endif
         endif
-    endif
+    endfunction
+    call s:signature(expand('%:p'), line('.') - 1, col('.') - 1, function("s:callback_showSignature"))
 endfunction
 
 function! fsharp#OnCursorMove()
@@ -212,7 +218,6 @@ function! fsharp#showF1Help()
     echo result
 endfunction
 
-
 let s:script_root_dir = expand('<sfile>:p:h') . "/../"
 let s:fsac = fnamemodify(s:script_root_dir . "fsac/fsautocomplete.dll", ":p")
 let g:fsharp#languageserver_command =
@@ -221,15 +226,28 @@ let g:fsharp#languageserver_command =
         \ '--mode', 'lsp'
     \ ]
 
-function! s:download()
-    echom "Downloading FSAC"
+function! s:download(branch)
+    echom "[FSAC] Downloading FSAC."
     let zip = s:script_root_dir . "fsac.zip"
     call system(
         \ 'curl -fLo ' . zip .  ' --create-dirs ' .
-        \ '"https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete.netcore.zip?branch=master"'
+        \ '"https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete.netcore.zip?branch=' . a:branch . '"'
         \ )
-    call system('unzip -d ' . s:script_root_dir . "/fsac " . zip)
-    echom "FSAC Downloaded"
+    if v:shell_error == 0
+        call system('unzip -d ' . s:script_root_dir . "/fsac " . zip)
+        echom "[FSAC] Updated FsAutoComplete to version " . a:branch . "" 
+    else
+        echom "[FSAC] Failed to update FsAutoComplete"
+    endif
+endfunction
+
+function! fsharp#updateFSAC(...)
+    if len(a:000) == 0
+        let branch = "master"
+    else
+        let branch = a:000[0]
+    endif
+    call s:download(branch)
 endfunction
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
Closes #1, #2.

This PR removes busy waiting for the result of endpoint calls and replaces them with callbacks. This can significantly improve editor response while the source code gets a bit harder to read.