### PR TITLE
F# Interactive Integration

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -191,15 +191,25 @@ let g:fsharp#show_signature_on_cursor_move = 1 " 0 to disable.
 let g:fsharp#fsi_command = "dotnet fsi"
 ~~~
 
+##### Change how FSI window is opened (default: `botright 10new`)
+
+It must create a new empty window and then focus to it.
+
+See [`:help opening-window`](http://vimdoc.sourceforge.net/htmldoc/windows.html#opening-window) for details.
+
+~~~.vim
+let g:fsharp#fsi_window_command = "botright vnew"
+~~~
+
 ##### Change the key mappings (default: `vscode`)
 
 * `vscode`:     Default. Same as in Ionide-VSCode (`Alt-Enter` to send, `Alt-@` to toggle terminal).
   - `<M-CR>` in Neovim / `<ESC><CR>` in Vim: Send line/selection to FSI.
   - `<M-@>`  in Neovim / `<ESC>@`    in Vim: Toggle FSI window.
-* `vim-fsharp`: Same as in [fsharp/vim-fsharp](https://github.com/fsharp/vim-fsharp#fsharp-interactive). Note that `<leader>` is mapped to backslash by default. See `:help mapleader`.
+* `vim-fsharp`: Same as in [fsharp/vim-fsharp](https://github.com/fsharp/vim-fsharp#fsharp-interactive). Note that `<leader>` is mapped to backslash by default. See [`:help mapleader`](http://vimdoc.sourceforge.net/htmldoc/map.html#mapleader).
   - `<leader>i` : Send line/selecion to FSI.
   - `<leader>e` : Toggle FSI window.
-* `custom`:     You must set both `g:fsharp#fsi_keymap_send` and  `g:fsharp#fsi_keymap_toggle` by yourself.
+* `custom`:     You must set both `g:fsharp#fsi_keymap_send` and `g:fsharp#fsi_keymap_toggle` by yourself.
   - `g:fsharp#fsi_keymap_send`   : Send line/selection to FSI.
   - `g:fsharp#fsi_keymap_toggle` : Toggle FSI window.
 * `none`:       Disables mapping.

--- a/README.mkd
+++ b/README.mkd
@@ -125,7 +125,7 @@ To be added as requested for F#-specific features.
 
 Ionide-vim has an integration with F# Interactive.
 
-FSI is displayed using the builtin `:terminal` feature introduced in Vim 8 / Neovim.
+FSI is displayed using the builtin `:terminal` feature introduced in Vim 8 / Neovim and can be used like in VSCode.
 
 #### `:FsiShow`
   - Shows F# Interactive windows.
@@ -142,9 +142,11 @@ FSI is displayed using the builtin `:terminal` feature introduced in Vim 8 / Neo
 #### `Alt-Enter`
   - When in normal mode, sends the current line to FSI.
   - When in visual mode, sends the selection to FSI.
+	- Sending code to FSI opens FSI window but the cursor does not focus to it. Unlike Neovim, Vim doesn't support asynchronous buffer updating so you have to input something (e.g. moving cursor) to see the result. You can change this behavior in settings.
 
 #### `Alt-@`
   - Toggles FSI window. FSI windows shown in different tabpages share the same FSI session.
+	- When opened, the cursor automatically focuses to the FSI window (unlike in `Alt-Enter` by default).
 
 You can customize the location of FSI, key mappings, etc. See [the documentation below](#f-interactive-settings).
 
@@ -188,10 +190,10 @@ let g:fsharp#show_signature_on_cursor_move = 1 " 0 to disable.
 ##### Change the F# Interactive command to be used within Ionide-vim (default: `dotnet fsi`)
 
 ~~~.vim
-let g:fsharp#fsi_command = "dotnet fsi"
+let g:fsharp#fsi_command = "fsharpi"
 ~~~
 
-##### Change how FSI window is opened (default: `botright 10new`)
+##### Customize how FSI window is opened (default: `botright 10new`)
 
 It must create a new empty window and then focus to it.
 
@@ -201,17 +203,25 @@ See [`:help opening-window`](http://vimdoc.sourceforge.net/htmldoc/windows.html#
 let g:fsharp#fsi_window_command = "botright vnew"
 ~~~
 
+##### Set if sending line/selection to FSI shoule make the cursor focus to FSI window (default: `0`)
+
+If you are using Vim, you might want to enable this to see the result without inputting something.
+
+~~~.vim
+let g:fsharp#fsi_focus_on_send = 1 " 0 to not to focus.
+~~~
+
 ##### Change the key mappings (default: `vscode`)
 
 * `vscode`:     Default. Same as in Ionide-VSCode (`Alt-Enter` to send, `Alt-@` to toggle terminal).
-  - `<M-CR>` in Neovim / `<ESC><CR>` in Vim: Send line/selection to FSI.
-  - `<M-@>`  in Neovim / `<ESC>@`    in Vim: Toggle FSI window.
+  - `<M-CR>` in Neovim / `<ESC><CR>` in Vim: Sends line/selection to FSI.
+  - `<M-@>`  in Neovim / `<ESC>@`    in Vim: Toggles FSI window.
 * `vim-fsharp`: Same as in [fsharp/vim-fsharp](https://github.com/fsharp/vim-fsharp#fsharp-interactive). Note that `<leader>` is mapped to backslash by default. See [`:help mapleader`](http://vimdoc.sourceforge.net/htmldoc/map.html#mapleader).
-  - `<leader>i` : Send line/selecion to FSI.
-  - `<leader>e` : Toggle FSI window.
+  - `<leader>i` : Sends line/selecion to FSI.
+  - `<leader>e` : Toggles FSI window.
 * `custom`:     You must set both `g:fsharp#fsi_keymap_send` and `g:fsharp#fsi_keymap_toggle` by yourself.
-  - `g:fsharp#fsi_keymap_send`   : Send line/selection to FSI.
-  - `g:fsharp#fsi_keymap_toggle` : Toggle FSI window.
+  - `g:fsharp#fsi_keymap_send`   : Sends line/selection to FSI.
+  - `g:fsharp#fsi_keymap_toggle` : Toggles FSI window.
 * `none`:       Disables mapping.
 
 ~~~.vim

--- a/README.mkd
+++ b/README.mkd
@@ -144,11 +144,11 @@ FSI is displayed using the builtin `:terminal` feature introduced in Vim 8 / Neo
 #### `Alt-Enter`
   - When in normal mode, sends the current line to FSI.
   - When in visual mode, sends the selection to FSI.
-	- Sending code to FSI opens FSI window but the cursor does not focus to it. Unlike Neovim, Vim doesn't support asynchronous buffer updating so you have to input something (e.g. moving cursor) to see the result. You can change this behavior in settings.
+  - Sending code to FSI opens FSI window but the cursor does not focus to it. Unlike Neovim, Vim doesn't support asynchronous buffer updating so you have to input something (e.g. moving cursor) to see the result. You can change this behavior in settings.
 
 #### `Alt-@`
   - Toggles FSI window. FSI windows shown in different tabpages share the same FSI session.
-	- When opened, the cursor automatically focuses to the FSI window (unlike in `Alt-Enter` by default).
+  - When opened, the cursor automatically focuses to the FSI window (unlike in `Alt-Enter` by default).
 
 You can customize the location of FSI, key mappings, etc. See [the documentation below](#f-interactive-settings).
 

--- a/README.mkd
+++ b/README.mkd
@@ -95,6 +95,8 @@ let g:LanguageClient_serverCommands = {
 
 This will configure FSAC to be used from LanguageClient-neovim.
 
+Note: if you append it before actually installing Ionide-vim, it will fail with `E121: Undefined variable: g:fsharp#languageserver_command`.
+
 ## Usage
 
 Opening either `*.fs`, `*.fsi` or `*.fsx` files should trigger syntax highlighting and other depending runtime files as well.
@@ -106,20 +108,20 @@ Refer to [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neov
 To be added as requested for F#-specific features.
 
 #### `:FSharpLoadWorkspaceAuto`
-  - Search a workspace (`sln` or `fsproj`) and then load it.
+  - Searches a workspace (`sln` or `fsproj`) and then load it.
   - Equivalent to `FSharp.workspaceMode = sln` in Ionide-VSCode.
   - Automatically called when you open F# files. Can be disabled in settings.
   - The deep level of directory hierarchy to search can also be configured in settings.
 
 #### `:FSharpParseProject <files>+`
-  - Load specified projects (`sln` or `fsproj`).
+  - Loads specified projects (`sln` or `fsproj`).
 
 #### `:FSharpReloadWorkspace`
-  - Reload all the projects currently loaded.
+  - Reloads all the projects currently loaded.
   - Automatically called when you save `.fsproj` files. Can be disabled in settings.
 
 #### `:FSharpUpdateFSAC`
-  - Download the latest build of FsAutoComplete to be used with Ionide-vim.
+  - Downloads the latest build of FsAutoComplete to be used with Ionide-vim.
 
 ### Working with F# Interactive
 

--- a/README.mkd
+++ b/README.mkd
@@ -118,35 +118,51 @@ To be added as requested for F#-specific features.
 #### `:FSharpUpdateFSAC`
   - Download the latest build of FsAutoComplete to be used with Ionide-vim.
 
+### Working with F# Interactive
+
+TODO
+
 ### Settings
 
 Refer to [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim) for features provided via Language Server Protocol.
 
 To be added as requested for F#-specific features.
 
-#### Enable/disable automatic calling of `:FSharpLoadWorkspaceAuto` on opening F# files (default: 1)
+#### Workspace Settings
+
+##### Enable/disable automatic calling of `:FSharpLoadWorkspaceAuto` on opening F# files (default: 1)
 
 ~~~.vim
 let g:fsharp#automatic_workspace_init = 1 " 0 to disable.
 ~~~
 
-#### Set the deep level of directory hierarchy when searching for sln/fsprojs (default: 2)
+##### Set the deep level of directory hierarchy when searching for sln/fsprojs (default: 2)
 
 ~~~.vim
 let g:fsharp#workspace_mode_peek_deep_level = 2
 
 ~~~
 
-#### Enable/disable automatic calling of `:FSharpReloadWorkspace` on saving `fsproj` (default: 1)
+##### Enable/disable automatic calling of `:FSharpReloadWorkspace` on saving `fsproj` (default: 1)
 
 ~~~.vim
 let g:fsharp#automatic_reload_workspace = 1 " 0 to disable.
 ~~~
 
-#### Show type signature at cursor position (default: 1)
+#### Editor Settings
+
+##### Show type signature at cursor position (default: 1)
 
 ~~~.vim
 let g:fsharp#show_signature_on_cursor_move = 1 " 0 to disable.
+~~~
+
+#### F# Interactive Settings
+
+##### Change the F# Interactive command to be used within Ionide-vim (default: `dotnet fsi`)
+
+~~~.vim
+let g:fsharp#fsharp_interactive_command = "dotnet fsi"
 ~~~
 
 ### Advanced Tips
@@ -159,7 +175,7 @@ If you are using neovim 0.4.0 or later, floating windows will be used for toolti
 if has('nvim') && exists('*nvim_open_win')
   augroup FSharpShowTooltip
     autocmd!
-    autocmd CursorHold *.fs call fsharp#showTooltip()
+    autocmd CursorHold *.fs,*.fsi,*.fsx call fsharp#showTooltip()
   augroup END
 endif
 ~~~

--- a/README.mkd
+++ b/README.mkd
@@ -2,6 +2,8 @@
 
 **F# support for Vim/Neovim**
 
+![ionide-vim](https://i.imgur.com/3RLcJw6.gif)
+
 _Part of the [Ionide](http://ionide.io) plugin suite._
 
 ## About Ionide-Vim
@@ -40,7 +42,7 @@ Feel free to [request features and/or file bug reports](https://github.com/ionid
 
 - Syntax highlighting
 - Auto completions
-- Error highlighting
+- Error highlighting and error list
 - Tooltips
 - Go to Definition
 - Find all references
@@ -49,6 +51,7 @@ Feel free to [request features and/or file bug reports](https://github.com/ionid
 - Show symbols in file
 - Find symbol in workspace
 - Show signature in status line
+- Integration with F# Interactive **(new!)**
 
 ## Getting Started
 
@@ -120,7 +123,30 @@ To be added as requested for F#-specific features.
 
 ### Working with F# Interactive
 
-TODO
+Ionide-vim has an integration with F# Interactive.
+
+FSI is displayed using the builtin `:terminal` feature introduced in Vim 8 / Neovim.
+
+#### `:FsiShow`
+  - Shows F# Interactive windows.
+
+#### `:FsiEval <expr>`
+  - Evaluates given expression in FSI.
+
+#### `:FsiEvalBuffer`
+  - Sends the content of current file to FSI.
+
+#### `:FsiReset`
+  - Resets the current FSI session.
+
+#### `Alt-Enter`
+  - When in normal mode, sends the current line to FSI.
+  - When in visual mode, sends the selection to FSI.
+
+#### `Alt-@`
+  - Toggles FSI window. FSI windows shown in different tabpages share the same FSI session.
+
+You can customize the location of FSI, key mappings, etc. See [the documentation below](#f-interactive-settings).
 
 ### Settings
 
@@ -162,7 +188,27 @@ let g:fsharp#show_signature_on_cursor_move = 1 " 0 to disable.
 ##### Change the F# Interactive command to be used within Ionide-vim (default: `dotnet fsi`)
 
 ~~~.vim
-let g:fsharp#fsharp_interactive_command = "dotnet fsi"
+let g:fsharp#fsi_command = "dotnet fsi"
+~~~
+
+##### Change the key mappings (default: `vscode`)
+
+* `vscode`:     Default. Same as in Ionide-VSCode (`Alt-Enter` to send, `Alt-@` to toggle terminal).
+  - `<M-CR>` in Neovim / `<ESC><CR>` in Vim: Send line/selection to FSI.
+  - `<M-@>`  in Neovim / `<ESC>@`    in Vim: Toggle FSI window.
+* `vim-fsharp`: Same as in [fsharp/vim-fsharp](https://github.com/fsharp/vim-fsharp#fsharp-interactive). Note that `<leader>` is mapped to backslash by default. See `:help mapleader`.
+  - `<leader>i` : Send line/selecion to FSI.
+  - `<leader>e` : Toggle FSI window.
+* `custom`:     You must set both `g:fsharp#fsi_keymap_send` and  `g:fsharp#fsi_keymap_toggle` by yourself.
+  - `g:fsharp#fsi_keymap_send`   : Send line/selection to FSI.
+  - `g:fsharp#fsi_keymap_toggle` : Toggle FSI window.
+* `none`:       Disables mapping.
+
+~~~.vim
+" custom mapping example
+let g:fsharp#fsi_keymap = "custom"
+let g:fsharp#fsi_keymap_send   = "<C-e>"
+let g:fsharp#fsi_keymap_toggle = "<C-@>"
 ~~~
 
 ### Advanced Tips

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -296,7 +296,7 @@ function! fsharp#openFsi(returnFocus)
                 if a:returnFocus | call s:win_gotoid_safe(current_win) | endif
             " open FSI: Neovim
             elseif has('nvim')
-                let s:fsi_job = termopen(g:fsharp#fsharp_interactive_command)
+                let s:fsi_job = termopen(g:fsharp#fsi_command)
                 if s:fsi_job > 0
                     let s:fsi_buffer = bufnr("%")
                 else
@@ -311,7 +311,7 @@ function! fsharp#openFsi(returnFocus)
                 \ "curwin": 1,
                 \ "term_finish": "close"
                 \ }
-                let s:fsi_buffer = term_start(g:fsharp#fsharp_interactive_command, options)
+                let s:fsi_buffer = term_start(g:fsharp#fsi_command, options)
                 if s:fsi_buffer != 0
                     if exists('*term_setkill') | call term_setkill(s:fsi_buffer, "term") | endif
                     let s:fsi_job = term_getjob(s:fsi_buffer)

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -266,7 +266,8 @@ endfunction
 
 let s:fsi_buffer = 0
 let s:fsi_job    = 0
-let s:fsi_height = 8
+let s:fsi_width  = 0
+let s:fsi_height = 0
 
 function! s:win_gotoid_safe(winid)
     function! s:vimReturnFocus(window)
@@ -285,9 +286,9 @@ function! fsharp#openFsi(returnFocus)
         " Neovim
         if exists('*termopen') || exists('*term_start')
             let current_win = win_getid()
-            " TODO: allow user to configure split style
-            botright new
-            execute 'resize' s:fsi_height
+            execute g:fsharp#fsi_window_command
+            if s:fsi_width  > 0 | execute 'vertical resize' s:fsi_width | endif
+            if s:fsi_height > 0 | execute 'resize' s:fsi_height | endif
             " if window is closed but FSI is still alive then reuse it
             if s:fsi_buffer != 0 && bufexists(str2nr(s:fsi_buffer))
                 exec 'b' s:fsi_buffer
@@ -338,6 +339,7 @@ function! fsharp#toggleFsi()
     if fsiWindowId > 0
         let current_win = win_getid()
         call win_gotoid(fsiWindowId)
+        let s:fsi_width = winwidth('%')
         let s:fsi_height = winheight('%')
         close
         call win_gotoid(current_win)

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -415,8 +415,6 @@ function! fsharp#sendAllToFsi()
     return fsharp#sendFsi(text)
 endfunction
 
-" TODO: send whole buffer
-
 let &cpo = s:cpo_save
 unlet s:cpo_save
 

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -368,7 +368,7 @@ function! fsharp#resetFsi()
 endfunction
 
 function! fsharp#sendFsi(text)
-    if fsharp#openFsi(1) > 0
+    if fsharp#openFsi(!g:fsharp#fsi_focus_on_send) > 0
         " Neovim
         if has('nvim')
             call chansend(s:fsi_job, a:text . ";;". "\n")

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -32,6 +32,9 @@ endif
 if !exists('g:fsharp#fsi_keymap')
     let g:fsharp#fsi_keymap = "vscode"
 endif
+if !exists('g:fsharp#fsi_window_command')
+    let g:fsharp#fsi_window_command = "botright 10new"
+endif
 
 let s:cpo_save = &cpo
 set cpo&vim

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -26,6 +26,9 @@ endif
 if !exists('g:fsharp#show_signature_on_cursor_move')
     let g:fsharp#show_signature_on_cursor_move = 1
 endif
+if !exists('g:fsharp#fsharp_interactive_command')
+    let g:fsharp#fsharp_interactive_command = "dotnet fsi"
+endif
 
 let s:cpo_save = &cpo
 set cpo&vim
@@ -49,13 +52,22 @@ if g:fsharp#automatic_workspace_init
 endif
 
 augroup FSharpLC_fs
-    autocmd! CursorMoved *.fs call fsharp#OnCursorMove()
+    autocmd!
+    autocmd CursorMoved *.fs,*.fsi,*.fsx  call fsharp#OnCursorMove()
 augroup END
 
 com! -buffer FSharpLoadWorkspaceAuto call fsharp#loadWorkspaceAuto()
 com! -buffer FSharpReloadWorkspace call fsharp#reloadProjects()
 com! -buffer -nargs=* FSharpUpdateFSAC call fsharp#updateFSAC(<f-args>)
 com! -buffer -nargs=* -complete=file FSharpParseProject call fsharp#loadProject(<f-args>)
+
+" TODO: :FsiEval :FsiEvalBuffer :FsiReset :FsiShow
+
+" TODO: allow user to customize key binding for these commands
+vnoremap <silent> <M-cr> :call fsharp#sendSelectionToFsi()<cr><esc>
+nnoremap <silent> <M-cr> :call fsharp#sendLineToFsi()<cr>
+nnoremap <silent> <M-/>  :call fsharp#sendLineToFsi()<cr>
+nnoremap <silent> <M-@>  :call fsharp#toggleFsi()<cr>
 
 let &cpo = s:cpo_save
 

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -26,8 +26,11 @@ endif
 if !exists('g:fsharp#show_signature_on_cursor_move')
     let g:fsharp#show_signature_on_cursor_move = 1
 endif
-if !exists('g:fsharp#fsharp_interactive_command')
-    let g:fsharp#fsharp_interactive_command = "dotnet fsi"
+if !exists('g:fsharp#fsi_command')
+    let g:fsharp#fsi_command = "dotnet fsi"
+endif
+if !exists('g:fsharp#fsi_keymap')
+    let g:fsharp#fsi_keymap = "vscode"
 endif
 
 let s:cpo_save = &cpo
@@ -61,25 +64,37 @@ com! -buffer FSharpReloadWorkspace call fsharp#reloadProjects()
 com! -buffer -nargs=* FSharpUpdateFSAC call fsharp#updateFSAC(<f-args>)
 com! -buffer -nargs=* -complete=file FSharpParseProject call fsharp#loadProject(<f-args>)
 
-" TODO: :FsiEval :FsiEvalBuffer :FsiReset :FsiShow
 com! -buffer -nargs=1 FsiEval call fsharp#sendFsi(<f-args>)
 com! -buffer FsiEvalBuffer call fsharp#sendAllToFsi()
 com! -buffer FsiReset call fsharp#resetFsi()
 com! -buffer FsiShow call fsharp#openFsi()
 
-" TODO: allow user to customize key binding for these commands
-if has('nvim')
-    vnoremap <silent> <M-cr> :call fsharp#sendSelectionToFsi()<cr><esc>
-    nnoremap <silent> <M-cr> :call fsharp#sendLineToFsi()<cr>
-    nnoremap <silent> <M-/>  :call fsharp#sendLineToFsi()<cr>
-    nnoremap <silent> <M-@>  :call fsharp#toggleFsi()<cr>
-    tnoremap <silent> <M-@>  <C-\><C-n>:call fsharp#toggleFsi()<cr>
-else
-    vnoremap <silent> <leader><cr> :call fsharp#sendSelectionToFsi()<cr><esc>
-    nnoremap <silent> <leader><cr> :call fsharp#sendLineToFsi()<cr>
-    nnoremap <silent> <leader></>  :call fsharp#sendLineToFsi()<cr>
-    nnoremap <silent> <C-@>  :call fsharp#toggleFsi()<cr>
-    tnoremap <silent> <C-@>  <C-\><C-n>:call fsharp#toggleFsi()<cr>
+if g:fsharp#fsi_keymap == "vscode"
+    if has('nvim')
+        let g:fsharp#fsi_keymap_send   = "<M-cr>"
+        let g:fsharp#fsi_keymap_toggle = "<M-@>"
+    else
+        let g:fsharp#fsi_keymap_send   = "<esc><cr>"
+        let g:fsharp#fsi_keymap_toggle = "<esc>@"
+    endif
+elseif g:fsharp#fsi_keymap == "vim-fsharp"
+    let g:fsharp#fsi_keymap_send   = "<leader>i"
+    let g:fsharp#fsi_keymap_toggle = "<leader>e"
+elseif g:fsharp#fsi_keymap == "custom"
+    let g:fsharp#fsi_keymap = "none"
+    if !exists('g:fsharp#fsi_keymap_send')
+        echoerr "g:fsharp#fsi_keymap_send is not set"
+    elseif !exists('g:fsharp#fsi_keymap_toggle')
+        echoerr "g:fsharp#fsi_keymap_toggle is not set"
+    else
+        let g:fsharp#fsi_keymap = "custom"
+    endif
+endif
+if g:fsharp#fsi_keymap != "none"
+    execute "vnoremap <silent>" g:fsharp#fsi_keymap_send ":call fsharp#sendSelectionToFsi()<cr><esc>"
+    execute "nnoremap <silent>" g:fsharp#fsi_keymap_send ":call fsharp#sendLineToFsi()<cr>"
+    execute "nnoremap <silent>" g:fsharp#fsi_keymap_toggle ":call fsharp#toggleFsi()<cr>"
+    execute "tnoremap <silent>" g:fsharp#fsi_keymap_toggle "<C-\\><C-n>:call fsharp#toggleFsi()<cr>"
 endif
 
 let &cpo = s:cpo_save

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -62,12 +62,25 @@ com! -buffer -nargs=* FSharpUpdateFSAC call fsharp#updateFSAC(<f-args>)
 com! -buffer -nargs=* -complete=file FSharpParseProject call fsharp#loadProject(<f-args>)
 
 " TODO: :FsiEval :FsiEvalBuffer :FsiReset :FsiShow
+com! -buffer -nargs=1 FsiEval call fsharp#sendFsi(<f-args>)
+com! -buffer FsiEvalBuffer call fsharp#sendAllToFsi()
+com! -buffer FsiReset call fsharp#resetFsi()
+com! -buffer FsiShow call fsharp#openFsi()
 
 " TODO: allow user to customize key binding for these commands
-vnoremap <silent> <M-cr> :call fsharp#sendSelectionToFsi()<cr><esc>
-nnoremap <silent> <M-cr> :call fsharp#sendLineToFsi()<cr>
-nnoremap <silent> <M-/>  :call fsharp#sendLineToFsi()<cr>
-nnoremap <silent> <M-@>  :call fsharp#toggleFsi()<cr>
+if has('nvim')
+    vnoremap <silent> <M-cr> :call fsharp#sendSelectionToFsi()<cr><esc>
+    nnoremap <silent> <M-cr> :call fsharp#sendLineToFsi()<cr>
+    nnoremap <silent> <M-/>  :call fsharp#sendLineToFsi()<cr>
+    nnoremap <silent> <M-@>  :call fsharp#toggleFsi()<cr>
+    tnoremap <silent> <M-@>  <C-\><C-n>:call fsharp#toggleFsi()<cr>
+else
+    vnoremap <silent> <leader><cr> :call fsharp#sendSelectionToFsi()<cr><esc>
+    nnoremap <silent> <leader><cr> :call fsharp#sendLineToFsi()<cr>
+    nnoremap <silent> <leader></>  :call fsharp#sendLineToFsi()<cr>
+    nnoremap <silent> <C-@>  :call fsharp#toggleFsi()<cr>
+    tnoremap <silent> <C-@>  <C-\><C-n>:call fsharp#toggleFsi()<cr>
+endif
 
 let &cpo = s:cpo_save
 

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -35,6 +35,9 @@ endif
 if !exists('g:fsharp#fsi_window_command')
     let g:fsharp#fsi_window_command = "botright 10new"
 endif
+if !exists('g:fsharp#fsi_focus_on_send')
+    let g:fsharp#fsi_focus_on_send = 0
+endif
 
 let s:cpo_save = &cpo
 set cpo&vim


### PR DESCRIPTION
Closes #9.

TODO:
- [x] Functionalities
  - [x] Open and toggle FSI in split window
  - [x] Send line/selection
  - [x] Send whole buffer (file)
  - [ ] ~~Send references from project (if possible)~~ => https://github.com/fsharp/FsAutoComplete/pull/442
- [x] Commands
  - [x] `:FsiEval`
  - [x] `:FsiEvalBuffer`
  - [x] `:FsiReset`
  - [x] `:FsiShow`
  - [ ] ~~And more~~
- [x] Customization via settings
  - [x] FSI executable location: `g:fsharp#fsharp_interactive_command`
  - [x] FSI window split style
  - [x] Key binding
  - [x] Focus to FSI on sending line/selection or don't
  - [ ] ~~And more~~
- [x] Docs