### PR TITLE
Support customizing FSAC server configurations

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -160,16 +160,15 @@ let g:fsharp#automatic_workspace_init = 1 " 0 to disable.
 
 ~~~.vim
 let g:fsharp#workspace_mode_peek_deep_level = 2
-
 ~~~
+
+#### Editor Settings
 
 ##### Enable/disable automatic calling of `:FSharpReloadWorkspace` on saving `fsproj` (default: 1)
 
 ~~~.vim
 let g:fsharp#automatic_reload_workspace = 1 " 0 to disable.
 ~~~
-
-#### Editor Settings
 
 ##### Show type signature at cursor position (default: 1)
 

--- a/README.mkd
+++ b/README.mkd
@@ -113,7 +113,7 @@ To be added as requested for F#-specific features.
 
 #### `:FSharpUpdateServerConfig`
   - Updates FSAC configuration.
-  - See [Workspace Settings](#workspace-settings) for details.
+  - See [FsAutoComplete Settings](#fsautocomplete-settings) for details.
 
 #### `:FSharpUpdateFSAC`
   - Downloads the latest build of FsAutoComplete to be used with Ionide-vim.
@@ -154,19 +154,19 @@ for features provided via Language Server Protocol.
 
 To be added as requested for F#-specific features.
 
-#### Workspace Settings
+#### FsAutoComplete Settings
 
-See [the documentation of FSAC](https://github.com/fsharp/FsAutoComplete#settings) for details. 
-
-* You can change their values at runtime and then notify the changes to FSAC by `:FSharpUpdateServerConfig`.
-* You can/should use `snake_case` for the setting names.
+* Ionide-vim uses `snake_case` for the setting names.
+  - For FSAC settings only, `CamelCase` can also be used (as it gets serialized to a F# record).
   - If both `snake_case` and `CamelCase` are specified, the `snake_case` one will be preferred.
+* You can change the values at runtime and then notify the changes to FSAC by `:FSharpUpdateServerConfig`.
 * Some of the settings may not work in Ionide-vim as it is lacking the corresponding feature of Ionide-VSCode.
 * If not specified, the recommended default values described on the FSAC's documentation will be used.
-  - If you are using `g:LanguageClient_settingsPath`, the recommended default values will override the settings loaded from it.
+  - If you are using a JSON configuration file though `g:LanguageClient_settingsPath`, the recommended default values will override the settings loaded from it.
   - You can disable this by `let g:fsharp#use_recommended_server_config = 0`.
 
-Below is a list of frequently used settings:
+See [the documentation of FSAC](https://github.com/fsharp/FsAutoComplete#settings)
+for the complete list of available settings. Frequently used ones are:
 
 ##### Enable/disable automatic calling of `:FSharpLoadWorkspaceAuto` on opening F# files (default: enabled)
 

--- a/README.mkd
+++ b/README.mkd
@@ -186,7 +186,7 @@ let g:fsharp#workspace_mode_peek_deep_level = 2
 let g:fsharp#exclude_project_directories = ['paket-files']
 ~~~
 
-##### Enable/disable linter and unused opens/declarations analyzer (default: all disabled)
+##### Enable/disable linter and unused opens/declarations analyzer (default: all enabled)
 
 You may want to bind `LanguageClient#textDocument_codeAction()` to some shortcut key. Refer to their docs.
 

--- a/README.mkd
+++ b/README.mkd
@@ -42,7 +42,7 @@ Feel free to [request features and/or file bug reports](https://github.com/ionid
 
 - Syntax highlighting
 - Auto completions
-- Error highlighting and error list
+- Error highlighting, error list, and quick fixes based on errors
 - Tooltips
 - Go to Definition
 - Find all references
@@ -52,6 +52,7 @@ Feel free to [request features and/or file bug reports](https://github.com/ionid
 - Find symbol in workspace
 - Show signature in status line
 - Integration with F# Interactive **(new!)**
+- Integration with FSharpLint (additional hints and quick fixes) **(new!)**
 
 ## Getting Started
 
@@ -110,6 +111,10 @@ To be added as requested for F#-specific features.
   - Reloads all the projects currently loaded.
   - Automatically called when you save `.fsproj` files. Can be disabled in settings.
 
+#### `:FSharpUpdateServerConfig`
+  - Updates FSAC configuration.
+  - See [Workspace Settings](#workspace-settings) for details.
+
 #### `:FSharpUpdateFSAC`
   - Downloads the latest build of FsAutoComplete to be used with Ionide-vim.
 
@@ -120,7 +125,7 @@ Ionide-vim has an integration with F# Interactive.
 FSI is displayed using the builtin `:terminal` feature introduced in Vim 8 / Neovim and can be used like in VSCode.
 
 #### `:FsiShow`
-  - Shows F# Interactive windows.
+  - Shows a F# Interactive window.
 
 #### `:FsiEval <expr>`
   - Evaluates given expression in FSI.
@@ -144,33 +149,59 @@ You can customize the location of FSI, key mappings, etc. See [the documentation
 
 ### Settings
 
-Refer to [LanguageClient-neovim](https://github.com/autozimu/LanguageClient-neovim) for features provided via Language Server Protocol.
+Refer to [LanguageClient-neovim's recommended settings](https://github.com/autozimu/LanguageClient-neovim/wiki/Recommended-Settings#recommended-settings)
+for features provided via Language Server Protocol.
 
 To be added as requested for F#-specific features.
 
 #### Workspace Settings
 
-##### Enable/disable automatic calling of `:FSharpLoadWorkspaceAuto` on opening F# files (default: 1)
+See [the documentation of FSAC](https://github.com/fsharp/FsAutoComplete#settings) for details. 
+
+* You can change their values at runtime and then notify the changes to FSAC by `:FSharpUpdateServerConfig`.
+* You can/should use `snake_case` for the setting names. If both `snake_case` and `CamelCase` are specified, the `snake_case` one will be preferred.
+* Some of the settings may not work in Ionide-vim as it is lacking the corresponding feature of Ionide-VSCode.
+
+Below is a list of frequently used settings:
+
+##### Enable/disable automatic calling of `:FSharpLoadWorkspaceAuto` on opening F# files (default: enabled)
 
 ~~~.vim
 let g:fsharp#automatic_workspace_init = 1 " 0 to disable.
 ~~~
 
-##### Set the deep level of directory hierarchy when searching for sln/fsprojs (default: 2)
+##### Set the deep level of directory hierarchy when searching for sln/fsprojs (default: `2`)
 
 ~~~.vim
 let g:fsharp#workspace_mode_peek_deep_level = 2
 ~~~
 
+##### Ignore specific directories when loading a workspace (default: empty)
+
+~~~.vim
+let g:fsharp#exclude_project_directories = ['paket-files']
+~~~
+
+##### Enable/disable linter and unused opens/declarations analyzer (default: all disabled)
+
+You may want to bind `LanguageClient#textDocument_codeAction()` to some shortcut key. Refer to their docs.
+
+~~~.vim
+" 0 to disable.
+let g:fsharp#linter = 1
+let g:fsharp#unused_opens_analyzer = 1
+let g:fsharp#unused_declarations_analyzer = 1
+~~~
+
 #### Editor Settings
 
-##### Enable/disable automatic calling of `:FSharpReloadWorkspace` on saving `fsproj` (default: 1)
+##### Enable/disable automatic calling of `:FSharpReloadWorkspace` on saving `fsproj` (default: enabled)
 
 ~~~.vim
 let g:fsharp#automatic_reload_workspace = 1 " 0 to disable.
 ~~~
 
-##### Show type signature at cursor position (default: 1)
+##### Show type signature at cursor position (default: enabled)
 
 ~~~.vim
 let g:fsharp#show_signature_on_cursor_move = 1 " 0 to disable.
@@ -180,8 +211,12 @@ let g:fsharp#show_signature_on_cursor_move = 1 " 0 to disable.
 
 ##### Change the F# Interactive command to be used within Ionide-vim (default: `dotnet fsi`)
 
+If you want to use a .NET Framework FSI instead of .NET Core one, set `g:fsharp#use_sdk_scripts` to `0`.
+See: https://github.com/fsharp/FsAutoComplete/pull/466#issue-324869672
+
 ~~~.vim
 let g:fsharp#fsi_command = "fsharpi"
+let g:fsharp#use_sdk_scripts = 0 " for net462 FSI
 ~~~
 
 ##### Customize how FSI window is opened (default: `botright 10new`)
@@ -194,7 +229,7 @@ See [`:help opening-window`](http://vimdoc.sourceforge.net/htmldoc/windows.html#
 let g:fsharp#fsi_window_command = "botright vnew"
 ~~~
 
-##### Set if sending line/selection to FSI shoule make the cursor focus to FSI window (default: `0`)
+##### Set if sending line/selection to FSI shoule make the cursor focus to FSI window (default: disabled)
 
 If you are using Vim, you might want to enable this to see the result without inputting something.
 

--- a/README.mkd
+++ b/README.mkd
@@ -159,8 +159,12 @@ To be added as requested for F#-specific features.
 See [the documentation of FSAC](https://github.com/fsharp/FsAutoComplete#settings) for details. 
 
 * You can change their values at runtime and then notify the changes to FSAC by `:FSharpUpdateServerConfig`.
-* You can/should use `snake_case` for the setting names. If both `snake_case` and `CamelCase` are specified, the `snake_case` one will be preferred.
+* You can/should use `snake_case` for the setting names.
+  - If both `snake_case` and `CamelCase` are specified, the `snake_case` one will be preferred.
 * Some of the settings may not work in Ionide-vim as it is lacking the corresponding feature of Ionide-VSCode.
+* If not specified, the recommended default values described on the FSAC's documentation will be used.
+  - If you are using `g:LanguageClient_settingsPath`, the recommended default values will override the settings loaded from it.
+  - You can disable this by `let g:fsharp#use_recommended_server_config = 0`.
 
 Below is a list of frequently used settings:
 

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -154,11 +154,17 @@ let s:config_keys_camel =
     \ ]
 let s:config_keys = []
 
+function! fsharp#toSnakeCase(str)
+    let sn = substitute(a:str, '\(\<\u\l\+\|\l\+\)\(\u\)', '\l\1_\l\2', 'g')
+    if sn == a:str | return tolower(a:str) | endif
+    return sn
+endfunction
+
 function! s:buildConfigKeys()
     if len(s:config_keys) == 0
         for key_camel in s:config_keys_camel
             let key = {}
-            let key.snake = substitute(key_camel.key, '\(\<\u\l\+\|\l\+\)\(\u\)', '\l\1_\l\2', 'g')
+            let key.snake = fsharp#toSnakeCase(key_camel.key)
             let key.camel = key_camel.key
             if has_key(key_camel, 'default')
                 let key.default = key_camel.default

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -176,7 +176,7 @@ function! g:fsharp#getServerConfig()
             let fsharp[key.camel] = g:fsharp#{key.snake}
         elseif exists('g:fsharp#' . key.camel)
             let fsharp[key.camel] = g:fsharp#{key.camel}
-        elseif has_key(key, 'default')
+        elseif has_key(key, 'default') && g:fsharp#use_recommended_server_config
             let g:fsharp#{key.snake} = key.default
             let fsharp[key.camel] = key.default
         endif

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -8,6 +8,9 @@ let b:did_fsharp_ftplugin = 1
 " set some defaults
 
 " FSAC server configuration
+if !exists('g:fsharp#use_recommended_server_config')
+    let g:fsharp#use_recommended_server_config = 1
+endif
 call fsharp#getServerConfig()
 
 if !exists('g:fsharp#automatic_reload_workspace')

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -65,6 +65,13 @@ if !has_key(g:LanguageClient_serverCommands, 'fsharp')
     let g:LanguageClient_serverCommands.fsharp = g:fsharp#languageserver_command
 endif
 
+if !exists('g:LanguageClient_rootMarkers')
+    let g:LanguageClient_rootMarkers = {}
+endif
+if !has_key(g:LanguageClient_rootMarkers, 'fsharp')
+    let g:LanguageClient_rootMarkers.fsharp = ['*.sln', '*.fsproj']
+endif
+
 if g:fsharp#automatic_workspace_init
     augroup LanguageClient_config
         autocmd!

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -6,12 +6,10 @@ endif
 let b:did_fsharp_ftplugin = 1
 
 " set some defaults
-if !exists('g:fsharp#automatic_workspace_init')
-    let g:fsharp#automatic_workspace_init = 1
-endif
-if !exists('g:fsharp#workspace_mode_peek_deep_level')
-    let g:fsharp#workspace_mode_peek_deep_level = 2
-endif
+
+" FSAC server configuration
+call fsharp#getServerConfig()
+
 if !exists('g:fsharp#automatic_reload_workspace')
     let g:fsharp#automatic_reload_workspace = 1
 endif
@@ -87,6 +85,7 @@ augroup END
 com! -buffer FSharpLoadWorkspaceAuto call fsharp#loadWorkspaceAuto()
 com! -buffer FSharpReloadWorkspace call fsharp#reloadProjects()
 com! -buffer -nargs=* -complete=file FSharpParseProject call fsharp#loadProject(<f-args>)
+com! -buffer FSharpUpdateServerConfig call fsharp#updateServerConfig()
 
 com! -buffer -nargs=1 FsiEval call fsharp#sendFsi(<f-args>)
 com! -buffer FsiEvalBuffer call fsharp#sendAllToFsi()


### PR DESCRIPTION
This PR implements the following things:

* Generates [`FSharpConfigDto`](https://github.com/fsharp/FsAutoComplete/blob/72a19d2a99f1a227705f3f488a5bd0c74560dbae/src/FsAutoComplete/LspHelpers.fs#L501) from setting variables such as `g:fsharp#automatic_workspace_init`
* Sends the configuration to FSAC via `workspace/didChangeConfiguration`

As a side effect:

* Ionide-vim now supports linter & analyzers
* Code actions are now more useful