### PR TITLE
remove unsupported flag which prevents FSAC from starting up correctly

### DIFF
--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -318,8 +318,7 @@ let s:script_root_dir = expand('<sfile>:p:h') . "/../"
 let s:fsac = fnamemodify(s:script_root_dir . "fsac/fsautocomplete.dll", ":p")
 let g:fsharp#languageserver_command =
     \ ['dotnet', s:fsac, 
-        \ '--background-service-enabled',
-        \ '--mode', 'lsp'
+        \ '--background-service-enabled'
     \ ]
 
 function! s:download(branch)


### PR DESCRIPTION
`--mode lsp` appears to no longer be supported by FSAC.

You can test this by manually invoking FSAC on the command line:
```
➜ dotnet ~/.vim/plugged/Ionide-vim/fsac/fsautoComplete.dll --background-service-enabled --mode lsp
ERROR: unrecognized argument: '--mode'.

➜ dotnet ~/.vim/plugged/Ionide-vim/fsac/fsautoComplete.dll --version
FsAutoComplete 0.38.2 (git sha de74a5c95a23c6791c45db64d282135a3925e00f)
```

Found using variation of minimal vimrc @https://github.com/autozimu/LanguageClient-neovim/blob/next/min-vimrc.vim

```
call plug#begin('~/.local/share/nvim/plugged')

Plug 'autozimu/LanguageClient-neovim', {
    \ 'branch': 'next',
    \ 'do': 'bash install.sh',
    \ }

Plug 'ionide/Ionide-vim', {
      \ 'do':  'make fsautocomplete',
      \}

call plug#end()
```


