### PR TITLE
update binary download location to github releases

### DIFF
--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -328,7 +328,7 @@ function! s:download(branch)
     let zip = s:script_root_dir . "fsac.zip"
     call system(
         \ 'curl -fLo ' . zip .  ' --create-dirs ' .
-        \ '"https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete.netcore.zip?branch=' . a:branch . '"'
+        \ '"https://github.com/fsharp/FsAutoComplete/releases/latest/download/fsautocomplete.netcore.zip"'
         \ )
     if v:shell_error == 0
         call system('unzip -o -d ' . s:script_root_dir . "/fsac " . zip)


### PR DESCRIPTION
Given that the other download link no longer works:

https://ci.appveyor.com/api/projects/fsautocomplete/fsautocomplete/artifacts/bin/pkgs/fsautocomplete.netcore.zip
{"message":"Artifact not found or access denied."}

It might be better to switch to github releases to not be tightly coupled to any one particular build system.

However, this does not support branches like the previous version did since I'm not sure how that is organized within the current CICD pipeline. 

Please test this before merging as I have not yet tested locally, but a similar manual script change worked in my setup to get the vim/ionide integration working.