### PR TITLE
Use . as a separator when importing modules

### DIFF
--- a/lua/ionide/init.lua
+++ b/lua/ionide/init.lua
@@ -13,10 +13,10 @@ function try_require(...)
 end
 
 local lspconfig_is_present = true
-local util = try_require('lspconfig/util')
+local util = try_require('lspconfig.util')
 if util == nil then
   lspconfig_is_present = false
-  util = require('ionide/util')
+  util = require('ionide.util')
 end
 
 local M = {}
@@ -63,7 +63,7 @@ end
 
 local function delegate_to_lspconfig(config)
   local lspconfig = require('lspconfig')
-  local configs = require('lspconfig/configs')
+  local configs = require('lspconfig.configs')
   if not (configs['ionide']) then
     configs['ionide'] = {
       default_config = get_default_config(),


### PR DESCRIPTION
While both `.` and `/` works, lua doesn't normalize the name. This means
that requiring `foo.bar` and `foo/bar` will load the same file twice.
nvim-lspconfig uses `.` (see https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig.lua#L1)
while this uses `/`, so the config isn't found when it tries to start it.
Tested on neovim 0.6.0, nvim-lspconfig 5b8624c.
