### PR TITLE
Set syntax to xml for *.fsproj files

### DIFF
--- a/ftdetect/fsharp.vim
+++ b/ftdetect/fsharp.vim
@@ -1,3 +1,3 @@
 " F#, fsharp
 autocmd BufNewFile,BufRead *.fs,*.fsi,*.fsx set filetype=fsharp
-autocmd BufNewFile,BufRead *.fsproj         set filetype=fsharp_project
+autocmd BufNewFile,BufRead *.fsproj         set filetype=fsharp_project syntax=xml


### PR DESCRIPTION
This commit sets the syntax to xml for *.fsproj files, to allow for proper syntax highlighting.