### PR TITLE
Expose s:workspace to consumers

### DIFF
--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -407,6 +407,10 @@ endfunction
 
 let s:workspace = []
 
+function! fsharp#getLoadedProjects()
+    return copy(s:workspace)
+endfunction
+
 function! fsharp#handle_notifyWorkspace(payload) abort
     let content = json_decode(a:payload.content)
     if content.Kind == 'projectLoading'


### PR DESCRIPTION
It would be nice to be able to read Ionide's state - e.g. I want to bind a command to "build everything", which is essentially "list all projects, shell-escape, concat with " ", and `dotnet build` the result".