### PR TITLE
fix #75: Add root_dir pattern for "*.fsx"

### DIFF
--- a/lua/ionide/init.lua
+++ b/lua/ionide/init.lua
@@ -43,7 +43,7 @@ local function get_default_config()
   result.name = "ionide"
   result.cmd = vim.g['fsharp#fsautocomplete_command']
   result.cmd_env = { DOTNET_ROLL_FORWARD = "LatestMajor" }
-  result.root_dir = util.root_pattern("*.sln", "*.fsproj", ".git")
+  result.root_dir = util.root_pattern("*.sln", "*.fsproj", ".git", "*.fsx")
   result.filetypes = {"fsharp"}
   result.autostart = true
   result.handlers = create_handlers()


### PR DESCRIPTION
Per discussion in #75, the LSP server is not started when opening a bare .fsx file (not in a directory with a git repo, project, or solution file), at least with some installations and setups.

Add wildcard pattern to match a root directory when it contains any "*.fsx" files, which, tautologically, and script file will match. Tested that this does start the server automatically for bare script files.