### PR TITLE
Split fsiextraparameters for fsac

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -382,13 +382,30 @@ let g:fsharp#use_sdk_scripts = 0 " for net462 FSI
 
 ##### Set additional runtime arguments passed to FSI
 
-*Default:* empty
+*Default:* `--readline-`
 
 Sets additional arguments of the FSI instance Ionide-vim spawns and changes the behavior of FSAC accordingly when editing fsx files.
+FSAC passes parameters on to the compiler for static analysis of script files.
+Not all parameters are shared between the compiler and interpreter, so FSAC splits these into 
+1. `FSIExtraInteractiveParameters`: specifically for use with the interpreter process 
+2. `FSIExtraSharedParameters`: those parameters which should be passed both to the interactive interpreter *and* the compiler
+
+Ionide-vim will pass all options from both of these parameters to the interpreter launched by `fsharp#fsi_command`
 
 ~~~.vim
-let g:fsharp#fsi_extra_parameters = ['--langversion:preview']
+let g:fsharp#fsi_extra_interactive_parameters = ['--readline-']
+let g:fsharp#fsi_extra_shared_parameters = ['--langversion:preview']
 ~~~
+
+There is a legacy option that is still supported by Ionide-vim and FSAC, `FSIExtraParameters`, that will be deprecated upstream in the future.
+This is a single option that combines the functionality of both mentioned above.
+Using interactive-only parameters in this option yields compiler errors.
+[See more discussion in the issue for FSAC](https://github.com/Ionide/fsautocomplete/issues/1210).
+
+It is recommended to migrate configuration to the new parameters.
+If you are currently using `FSIExtraParameters`, simply copying the options to `FSIExtraSharedParameters` will preserve all current behavior.
+
+Unti
 
 ##### Customize how FSI window is opened
 

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -193,6 +193,8 @@ let s:config_keys_camel =
     \     {'key': 'UseSdkScripts', 'default': 1},
     \     {'key': 'dotNetRoot'},
     \     {'key': 'fsiExtraParameters', 'default': []},
+    \     {'key': 'fsiExtraInteractiveParameters', 'default': ['--readline-']},
+    \     {'key': 'fsiExtraSharedParameters', 'default': []},
     \     {'key': 'fsiCompilerToolLocations', 'default': []},
     \     {'key': 'TooltipMode', 'default': 'full'},
     \     {'key': 'GenerateBinlog', 'default': 0},
@@ -555,6 +557,12 @@ endfunction
 function! s:get_fsi_command()
     let cmd = g:fsharp#fsi_command
     for prm in g:fsharp#fsi_extra_parameters
+        let cmd = cmd . " " . prm
+    endfor
+    for prm in g:fsharp#fsi_extra_interactive_parameters
+        let cmd = cmd . " " . prm
+    endfor
+    for prm in g:fsharp#fsi_extra_shared_parameters
         let cmd = cmd . " " . prm
     endfor
     return cmd

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -192,7 +192,7 @@ let s:config_keys_camel =
     \     {'key': 'LineLens', 'default': {'enabled': 'never', 'prefix': ''}},
     \     {'key': 'UseSdkScripts', 'default': 1},
     \     {'key': 'dotNetRoot'},
-    \     {'key': 'fsiExtraParameters', 'default': []},
+    \     {'key': 'fsiExtraParameters'},
     \     {'key': 'fsiExtraInteractiveParameters', 'default': ['--readline-']},
     \     {'key': 'fsiExtraSharedParameters', 'default': []},
     \     {'key': 'fsiCompilerToolLocations', 'default': []},

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -556,9 +556,12 @@ endfunction
 
 function! s:get_fsi_command()
     let cmd = g:fsharp#fsi_command
-    for prm in g:fsharp#fsi_extra_parameters
-        let cmd = cmd . " " . prm
-    endfor
+    if exists("g:fsharp#fsi_extra_parameters")
+        echom "[Ionide-vim]: `g:fsharp#fsi_extra_parameters` is being deprecated. Migrate to `g:fsharp#fsi_extra_interactive_parameters` and `g:fsharp_extra_shared_parameters`."
+        for prm in g:fsharp#fsi_extra_parameters
+            let cmd = cmd . " " . prm
+        endfor
+    endif
     for prm in g:fsharp#fsi_extra_interactive_parameters
         let cmd = cmd . " " . prm
     endfor


### PR DESCRIPTION
- Add conditional check and warning for use of old `fsi_extra_parameters`
- Update README.mkd for new parameters
- Remove default empty string for FSIExtraParameters
    - This gets sent to FSAC and, despite being a no-op, it is different than a `None` in the FSAC options.
      We do not want to mix old and new fsi extra parameters.
- Add new config options for extra parameters
    - Add `fsiExtraInteractiveParameters` and `fsiExtraSharedParameters`, which should both be used in favor of the old `fsiExtraParameters`.
    - Some fsi parameters are exclusive to the interpreter and have no compiler equivalent.
      FSAC will now pass the shared parameters to the compiler and not the interactive parameters.
    - Ionide-vim will append all parameters from both options to the execution of the interpreter (usually `dotnet fsi`).
    - `fsiExtraParameters` will be deprecated and removed from FSAC, so it is best to migrate away from that.
    - See https://github.com/ionide/FsAutoComplete/issues/1210 for more detail.

implements #82
