### PR TITLE
Add exclusion config for parens analyzer

### DIFF
--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -190,6 +190,7 @@ let s:config_keys_camel =
     \     {'key': 'SimplifyNameAnalyzer', 'default': 0},
     \     {'key': 'SimplifyNameAnalyzerExclusions', 'default': []},
     \     {'key': 'UnnecessaryParenthesesAnalyzer', 'default': 0},
+    \     {'key': 'UnnecessaryParenthesesAnalyzerExclusions', 'default': []},
     \     {'key': 'ResolveNamespaces', 'default': 1},
     \     {'key': 'EnableReferenceCodeLens', 'default': 1},
     \     {'key': 'EnableAnalyzers', 'default': 0},


### PR DESCRIPTION
Resolves https://github.com/ionide/FsAutoComplete/discussions/1360 by applying the config technique used for the other FCS analyzers in https://github.com/ionide/FsAutoComplete/pull/1120, https://github.com/ionide/ionide-vscode-fsharp/pull/1887, and https://github.com/ionide/Ionide-vim/pull/81. Depends on https://github.com/ionide/FsAutoComplete/pull/1363.