### PR TITLE
 Send text to FSI with current file's directory context

### DIFF
--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -666,16 +666,24 @@ function! fsharp#resetFsi()
 endfunction
 
 function! fsharp#sendFsi(text)
-    if fsharp#openFsi(!g:fsharp#fsi_focus_on_send) > 0
-        " Neovim
-        if has('nvim')
-            call chansend(s:fsi_job, a:text . s:newline . ";;". s:newline)
-        " Vim 8
-        else
-            call term_sendkeys(s:fsi_buffer, a:text . "\<cr>" . ";;" . "\<cr>")
-            call term_wait(s:fsi_buffer)
-        endif
-    endif
+     if fsharp#openFsi(!g:fsharp#fsi_focus_on_send) > 0
+         " Neovim
+         let l:current_dir = expand('%:p:h')
+         " Ensure directory exists before trying to cd into it
+         if !empty(l:current_dir) && isdirectory(l:current_dir)
+             let l:cd_command = printf('#cd @"%s"', l:current_dir)
+             let l:full_text = l:cd_command . s:newline . a:text
+         else
+             let l:full_text = a:text " Don't send #cd if directory is invalid/empty
+         endif
+         if has('nvim')
+             call chansend(s:fsi_job, l:full_text . s:newline . ";;". s:newline)
+         " Vim 8
+         else
+             call term_sendkeys(s:fsi_buffer, l:full_text . "\<cr>" . ";;" . "\<cr>")
+             call term_wait(s:fsi_buffer)
+         endif
+     endif
 endfunction
 
 " https://stackoverflow.com/a/6271254


### PR DESCRIPTION
**Problem statement**
Currently when sending a line to FSI with `Alt+Enter`, we have to be careful that we first `cd` to the correct location before we execute code like `#load ./someFile.fsx` because currently we are using neovim's pwd which is the directory from which neovim is launched. 

This is what this PR is about. Effectively, it is now possible to launch neovim from say:

`/home/user1`

open up `/home/user1/Work/Project/file.fsx` while still in neovim and be able to successfully send the following:

`#load ./anotherFile.fsx` to FSI

**Disclaimer**
I have absolutely no idea about vimscript. However, with the help of AI, I've come up with this solution which works for my particular use case and from what I gather from the code, it seems to be doing the right thing. I have no idea whether beyond sending a line/selection to FSI whether this works for other use cases.

I'd be happy to improve if need be. 

Also I've only tested briefly in neovim again for my use case. 
