### PR TITLE
feat: normalize leading spaces fsi

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -457,6 +457,14 @@ If you are using Vim, you might want to enable this to see the result without in
 let g:fsharp#fsi_focus_on_send = 1 " 0 to not to focus.
 ~~~
 
+##### Set if common leading spaces are trimmed from line/selection before sending to FSI
+
+*Default:* enabled
+
+~~~.vim
+let g:fsharp#fsi_trim_indentation = 1 " 0 to disable.
+~~~
+
 ##### Change the key mappings
 
 *Default:* `vscode`

--- a/autoload/fsharp.vim
+++ b/autoload/fsharp.vim
@@ -294,6 +294,10 @@ function! fsharp#loadConfig()
     if !exists('g:fsharp#fsi_focus_on_send')
         let g:fsharp#fsi_focus_on_send = 0
     endif
+    if !exists('g:fsharp#fsi_trim_indentation')
+        let g:fsharp#fsi_trim_indentation = 1
+    endif
+
     if !exists('g:fsharp#backend')
         if has('nvim-0.5')
             if exists('g:LanguageClient_loaded')
@@ -729,14 +733,22 @@ endfunction
 function! fsharp#sendSelectionToFsi() range
     let lines = s:get_visual_selection()
     exec 'normal' len(lines) . 'j'
-    let trimmed_lines = s:trim_common_leading_spaces(lines)
+    if g:fsharp#fsi_trim_indentation == 1
+        let trimmed_lines = s:trim_common_leading_spaces(lines)
+    else
+        let trimmed_lines = lines
+    endif
     let text = join(trimmed_lines, s:newline)
     return fsharp#sendFsi(text)
 endfunction
 
 function! fsharp#sendLineToFsi()
     let lines = [getline('.')]
-    let trimmed_lines = s:trim_common_leading_spaces(lines)
+    if g:fsharp#fsi_trim_indentation == 1
+        let trimmed_lines = s:trim_common_leading_spaces(lines)
+    else
+        let trimmed_lines = lines
+    endif
     let text = trimmed_lines[0]
     exec 'normal j'
     return fsharp#sendFsi(text)


### PR DESCRIPTION
* remove common leading spaces from current/selected line(s) before sending to FSI
* enabled by default (can be disabled with `g:fsharp#fsi_trim_indentation = 0`)
* updated README with new param

fixes #101 